### PR TITLE
add skip flag to paste the code without confirmation

### DIFF
--- a/cmd/agg/main.go
+++ b/cmd/agg/main.go
@@ -13,6 +13,7 @@ func main() {
 	mainPath := flag.String("main", "", "Main Go file path")
 	importPaths := flag.String("import", "", "Comma-separated list of import file paths")
 	prefixesToRemove := flag.String("prefix", "", "Comma-separated list of prefixes to remove")
+	isSkipPasteConfirmation := flag.Bool("skip", false, "Skip confirmation before pasting")
 	flag.Parse()
 
 	if *mainPath == "" || *importPaths == "" || *prefixesToRemove == "" {
@@ -31,13 +32,21 @@ func main() {
 
 	fmt.Println(finalCode)
 
-	if pkg.GetUserConfirmation("Do you want to overwrite the main file with this code? (y/n): ") {
+	if *isSkipPasteConfirmation {
 		if err := pkg.OverwriteFile(*mainPath, finalCode); err != nil {
 			fmt.Printf("Error writing to file: %v\n", err)
 			os.Exit(1)
 		}
 		fmt.Println("File overwritten successfully.")
 	} else {
-		fmt.Println("File not overwritten.")
+		if pkg.GetUserConfirmation("Do you want to overwrite the main file with this code? (y/n): ") {
+			if err := pkg.OverwriteFile(*mainPath, finalCode); err != nil {
+				fmt.Printf("Error writing to file: %v\n", err)
+				os.Exit(1)
+			}
+			fmt.Println("File overwritten successfully.")
+		} else {
+			fmt.Println("File not overwritten.")
+		}
 	}
 }


### PR DESCRIPTION
if you add `-skip` flag like following, you can paste the code to Main file without confirmation in terminal

```bash
agg \
-main test-dir/chap1/main.go \
-import test-dir/chap1/code/problem.go,test-dir/util/util.go \
-prefix code,util \
-skip
```